### PR TITLE
fix: add error handling for WiFi.scanNetworks() in /scan endpoint

### DIFF
--- a/src/EasyWiFi.cpp
+++ b/src/EasyWiFi.cpp
@@ -298,8 +298,17 @@ void EasyWiFi::startPortal() {
   });
   
   server.on("/scan", [this]() {
-    int networks = WiFi.scanNetworks(); 
-    Serial.printf("Scan complete: %d", networks);
+    int networks = WiFi.scanNetworks();
+    
+    // Check for scan errors
+    if (networks < 0) {
+      Serial.printf("WiFi scan failed with error code: %d\n", networks);
+      server.send(500, "application/json", 
+                  "{\"error\":\"WiFi scan failed\",\"code\":" + String(networks) + "}");
+      return;
+    }
+    
+    Serial.printf("Scan complete: %d networks found\n", networks);
     String json = "[";
 
     for (int i = 0; i < networks; i++) {
@@ -312,6 +321,7 @@ void EasyWiFi::startPortal() {
     }
     json += "]";
 
+    WiFi.scanDelete(); // Clean up scan results from memory
     server.send(200, "application/json", json);
   });
 


### PR DESCRIPTION
## Description
This PR fixes missing error handling in the `/scan` endpoint when `WiFi.scanNetworks()` fails.

## Problem
- `WiFi.scanNetworks()` can return negative values on error (e.g., -1 for WIFI_SCAN_FAILED, -2 for WIFI_SCAN_RUNNING)
- The code doesn't check for negative values before iterating through results
- When scan fails, client receives empty array `[]` with 200 OK status, masking the error
- No memory cleanup (`WiFi.scanDelete()`) is performed
- Serial output doesn't indicate scan failure, making debugging difficult

## Solution
- Added error checking for `networks < 0`
- Return 500 error with JSON error response when scan fails
- Added `WiFi.scanDelete()` to prevent memory leak
- Improved serial output to indicate scan success/failure
- Proper error reporting to client instead of masking errors

## Changes Made
- Modified `/scan` endpoint in `src/EasyWiFi.cpp` (lines 300-326)
- Added error handling with appropriate HTTP status codes
- Added memory cleanup for scan results
- Improved logging for better debugging

## Testing
- ✅ Code compiles without errors
- ✅ No linting issues introduced
- Manual testing recommended: Force scan failure by testing during WiFi busy state

## Impact
- **Low severity** but improves user experience
- Users now see proper error messages instead of empty network lists
- Prevents potential memory leaks
- Makes debugging connectivity issues easier

Fixes #10